### PR TITLE
Handle the case where no gapi object exists.

### DIFF
--- a/static/urlshorten-google.js
+++ b/static/urlshorten-google.js
@@ -3,7 +3,7 @@ function googleJSClientLoaded() {
 }
 
 function shortenURL(url, done) {
-    if (!gapi.client) {
+    if (!window.gapi || !gapi.client) {
         // Load the Google APIs client library asynchronously, then the
         // urlshortener API, and finally come back here.
         $(document.body).append('<script src="https://apis.google.com/js/client.js?onload=googleJSClientLoaded">');


### PR DESCRIPTION
This can happen when sharing has been disabled.

Fixes #61.