### PR TITLE
Switch to memwatch-next

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,7 +54,7 @@ var port = props.get('gcc-explorer', 'port', 10240);
 var staticMaxAgeMs = props.get('gcc-explorer', 'staticMaxAgeMs', 0);
 
 function initializeMemwatch() {
-    var memwatch = require('memwatch');
+    var memwatch = require('memwatch-next');
     console.log("Initial GC");
     memwatch.gc();
     // Everything else happens a little later to let the initial GC finish.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "heapdump": "0.3.x",
     "http-proxy": "1.8.x",
     "lru-cache": "2.5.x",
-    "memwatch": "0.2.x",
+    "memwatch-next": "0.2.x",
     "morgan": "1.5.x",
     "promise": "6.1.x",
     "promise-queue": "2.1.x",


### PR DESCRIPTION
memwatch doesn't work with node 0.12, so switch it out for memwatch-next