### PR TITLE
Fix sorting of examples

### DIFF
--- a/lib/sources/builtin.js
+++ b/lib/sources/builtin.js
@@ -38,7 +38,7 @@
             var nicename = file.replace(/\.cpp$/, '');
             return {urlpart: nicename, name: nicename.replace(/_/g, ' '), path: path.join(sourcePath, file)};
         }).sort(function (x, y) {
-            return y.name < x.name;
+            return x.name.localeCompare(y.name);
         });
     var byUrlpart = {};
     examples.forEach(function (e) {


### PR DESCRIPTION
Compare function should return negative, 0, or a positive integer.
Not true or false.

Signed-off-by: Ola Jeppsson <ola@adapteva.com>