### PR TITLE
Add ability to set per-compiler options

### DIFF
--- a/app.js
+++ b/app.js
@@ -238,6 +238,7 @@ function configuredCompilers() {
             exe: exe,
             name: props("name", name),
             alias: props("alias"),
+            options: props("options"),
             versionFlag: props("versionFlag"),
             is6g: !!props("is6g", false),
             intelAsm: props("intelAsm", ""),

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -244,6 +244,9 @@ Compile.prototype.compile = function (source, compiler, options, filters) {
         var dirPath = info.dirPath;
         var postProcess = compilerProps("postProcess");
         var outputFilename = path.join(dirPath, 'output.S');
+        if (compilerInfo.options) {
+           options = options.concat(compilerInfo.options.split(" "));
+        }
         if (compilerInfo.intelAsm && filters.intel && !filters.binary) {
             options = options.concat(compilerInfo.intelAsm.split(" "));
         }


### PR DESCRIPTION
I found this useful as I have many cross-compilers, and not all have ``-fexceptions`` on by default.

Also, I'm providing a choice for both 32bit and 64bit, but using the same compiler.

```
compilers=gdc32:gdc64
compiler.gdc32.exe=/srv/compilers/bin/gdc-5
compiler.gdc32.options=-m32
compiler.gdc64.exe=/srv/compilers/bin/gdc-5
compiler.gdc64.options=-m64
```

(Running site here: http://explore.dgnu.org )