### PR TITLE
Use higher-resolution "Fork me on GitHub" ribbon

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -257,9 +257,11 @@ func main() {}
                             position: "absolute",
                             top: "40px",
                             right: 0,
-                            border: 0
+                            border: 0,
+                            width: "149px",
+                            height: "149px"
                         })
-                        .attr('src', 'https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png')
+                        .attr('src', 'http://aral.github.com/fork-me-on-github-retina-ribbons/right-green@2x.png')
                         .attr('alt', 'Fork me on GitHub')
                         .attr('useMap', '#ghm')
                         .appendTo(document.body)


### PR DESCRIPTION
so it looks better on high-DPI displays.

From https://ar.al/scribbles/fork-me-on-github-retina-ribbons/.

Comparison:

![ads](https://cloud.githubusercontent.com/assets/7543552/14193522/351ce2b6-f7ae-11e5-94ed-153a9c49442f.png)
