### PR TITLE
Don't try to link in dl library on FreeBSD.

### DIFF
--- a/c-preload/Makefile
+++ b/c-preload/Makefile
@@ -1,7 +1,13 @@
+ifeq (FreeBSD,$(shell uname -s))
+    LDL :=
+else
+    LDL := -ldl
+endif
+
 all: libpreload.so
 
 libpreload.so: preload.c
-	$(CC) -std=c99 -shared -O1 -fPIC $^ -o $@ -ldl
+	$(CC) -std=c99 -shared -O1 -fPIC $^ -o $@ $(LDL)
 
 .PHONY: test clean
 test: libpreload.so


### PR DESCRIPTION
As per: http://lists.freebsd.org/pipermail/freebsd-questions/2008-March/172079.html

> The dlopen/dlsym functions are built into libc on FreeBSD, so there's no need for a libdl