### PR TITLE
Fixes rejection of any user provided compiler option optionsBlacklistRe isn't set

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -64,7 +64,7 @@ function Compile(compilers) {
         self.compilersById[compiler.id] = compiler;
     });
     this.okOptions = new RegExp(gccProps('optionsWhitelistRe', '.*'));
-    this.badOptions = new RegExp(gccProps('optionsBlacklistRe'));
+    this.badOptions = new RegExp(gccProps('optionsBlacklistRe', '(?!)'));
     this.cache = LRU({
         max: gccProps('cacheMb') * 1024 * 1024,
         length: function (n) {


### PR DESCRIPTION
* fixes an issue where the user cannot specify any compiler options if the optionsBlacklistRe config option isn't specified (i assume that this is not the intended behavior)
* this is due to the fact that if the black list regex isn't specified, gccProps returns 'undefined'; in JS "new RegExp(undefined)" evaluates to /(?:)/ which matches any string with a non-null result of empty string
* as a result, any option is considered as blacklisted
* this commit sets the option default to /(?!)/ which truly doesn't match anything (i.e. the match is null for any string)