### PR TITLE
fix typing '#' in triggering emacs keybind

### DIFF
--- a/static/compiler.js
+++ b/static/compiler.js
@@ -112,6 +112,9 @@ function Compiler(domRoot, origFilters, windowLocalPrefix, onChangeCallback, lan
         useCPP: true,
         mode: cmMode
     });
+    cppEditor.setOption("extraKeys", {
+      "Alt-F": false
+    });
     cppEditor.on("change", function () {
         if ($('.autocompile').hasClass('active')) {
             onChange();


### PR DESCRIPTION
Related to this ticket: https://github.com/codemirror/CodeMirror/issues/4066