### PR TITLE
Better alignment hint for "max array opt"

### DIFF
--- a/examples/c++/max_array_opt.cpp
+++ b/examples/c++/max_array_opt.cpp
@@ -1,16 +1,7 @@
 // Compile with -O3 -march=native to see autovectorization
-void maxArray(double* __restrict x, double* __restrict y) {
-    // Alignment hints supported on GCC 4.7+ and any compiler
-    // supporting the appropriate builtin (clang 3.6+).
-#ifndef __has_builtin
-#define __has_builtin(x) 0
-#endif
-#if __GNUC__ > 4 \
-        || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7) \
-        || __has_builtin(__builtin_assume_aligned)
-    x = static_cast<double*>(__builtin_assume_aligned(x, 64));
-    y = static_cast<double*>(__builtin_assume_aligned(y, 64));
-#endif
+typedef double __attribute__((aligned(64))) aligned_double;
+
+void maxArray(aligned_double* __restrict x, aligned_double* __restrict y) {
     for (int i = 0; i < 65536; i++) {
         x[i] = ((y[i] > x[i]) ? y[i] : x[i]);
     }


### PR DESCRIPTION
A more compatible and concise hint for memory alignment in the "max array opt" example.