### PR TITLE
Fixes the status button so it works on Mozilla Firefox

### DIFF
--- a/static/compiler.js
+++ b/static/compiler.js
@@ -114,8 +114,8 @@ define(function (require) {
         var outputConfig = _.bind(function () {
             return output.getComponent(this.id, this.sourceEditorId);
         }, this);
-        this.container.layoutManager.createDragSource(this.domRoot.find(".status"), outputConfig);
-        this.domRoot.find(".status").click(_.bind(function () {
+        this.container.layoutManager.createDragSource(this.domRoot.find(".status").parent(), outputConfig);
+        this.domRoot.find(".status").parent().click(_.bind(function () {
             var insertPoint = hub.findParentRowOrColumn(this.container)
                 || this.container.layoutManager.root.contentItems[0];
             insertPoint.addChild(outputConfig());
@@ -286,7 +286,7 @@ define(function (require) {
         var warns = !failed && !!allText;
         status.toggleClass('error', failed);
         status.toggleClass('warning', warns);
-        status.attr('title', allText);
+        status.parent().attr('title', allText);
         this.eventHub.emit('compileResult', this.id, this.compiler, result);
     };
 


### PR DESCRIPTION
The status button (the button with the exclamation mark and triangle), does not work properly in Mozilla Firefox, the title does not show up, because it is an attribute on the `span`-element, and not the button itself, and similarly the events, that allows creating an output area, also don't work as they are attached to the `span`-element.

This diff modifies `static/compiler.js` slightly, so the `title`-attribute and the events are applied to the parent `button`-element which fixes it on Mozilla Firefox, and also makes the whole button work, as opposed to only the part that has the status icon on it.

I have played around with this change, and have not found any bugs with it, and have tested in both Mozilla Firefox, and Google Chrome, where it seems to work as it should.