### PR TITLE
Add LDC to Amazon config

### DIFF
--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -1,4 +1,4 @@
-compilers=gdc48:gdc49:gdc52
+compilers=gdc48:gdc49:gdc52:ldc017:ldc100
 defaultCompiler=gdc52
 # URL compatibility...
 compiler.gdc49.exe=/opt/gcc-explorer/gdc4.9.3/x86_64-pc-linux-gnu/bin/gdc
@@ -10,3 +10,9 @@ compiler.gdc48.name=gdc 4.8.2
 
 compiler.gdc52.exe=/opt/gcc-explorer/gdc5.2.0/x86_64-pc-linux-gnu/bin/gdc
 compiler.gdc52.name=gdc 5.2.0
+
+compiler.ldc017.exe=/opt/gcc-explorer/ldc0.17.2/ldc2-0.17.2-linux-x86_64/bin/ldc2
+compiler.ldc017.name=ldc 0.17.2 (dlang 2.068.2)
+
+compiler.ldc100.exe=/opt/gcc-explorer/ldc1.0.0/ldc2-1.0.0-linux-x86_64/bin/ldc2
+compiler.ldc100.name=ldc 1.0.0 (dlang 2.070.2)


### PR DESCRIPTION
This should add LDC to the list of available compilers on d.godbolt.org.