### PR TITLE
Add support for the LDC compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,15 @@ endif
 .PHONY: dist lint
 prereqs: optional-d-support node_modules c-preload bower_modules
 
-ifeq "" "$(shell which gdc)"
-optional-d-support:
-	@echo "D language support disabled"
-else
+ifneq "" "$(shell which gdc)"
 optional-d-support:
 	$(MAKE) -C d
+else ifneq "" "$(shell which ${DMD})"
+optional-d-support:
+	$(MAKE) -C d
+else
+optional-d-support:
+	@echo "D language support disabled"
 endif
 
 NODE_MODULES=.npm-updated

--- a/app.js
+++ b/app.js
@@ -337,6 +337,8 @@ function configuredCompilers() {
             is6g: !!props("is6g", false),
             isCl: !!props("isCl", false),
             intelAsm: props("intelAsm", ""),
+            asmFlag: props("asmFlag", "-S"),
+            outputFlag: props("outputFlag", "-o"),
             needsMulti: !!props("needsMulti", true),
             supportsBinary: !!props("supportsBinary", true),
             postProcess: props("postProcess", "")

--- a/d/Makefile
+++ b/d/Makefile
@@ -1,6 +1,10 @@
 GDC?=gdc
 demangle: demangle.d
+ifeq "" "$(shell which $DMD)"
+	$(DMD) -O -release $< -of$@
+else
 	$(GDC) -O2 $< -o $@
+endif
 
 clean:
 	rm -f demangle.o demangle

--- a/d/demangle.d
+++ b/d/demangle.d
@@ -26,11 +26,26 @@ import std.stdio;
 import std.demangle;
 import std.regex;
 
-auto idRegex = ctRegex!("[_$a-zA-Z][_$a-zA-Z0-9]*", "g");
+auto idRegex = ctRegex!("\\b_?_D[0-9a-zA-Z_]+\\b", "g");
 
 void main() {
     string dem(Captures!(string) m) {
-        return demangle(m.hit);
+        if (m.hit[1] == '_') {
+            // Could be a symbolname with double leading underscore
+            auto result = demangle(m.hit[1..$]);
+            if (result == m.hit[1..$])
+            {
+                return m.hit;
+            }
+            else
+            {
+                return result;
+            }
+        }
+        else
+        {
+            return demangle(m.hit);
+        }
     }
 
     foreach (line; stdin.byLine()) {

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -13,6 +13,12 @@ compiler.gdc52.name=gdc 5.2.0
 
 compiler.ldc017.exe=/opt/gcc-explorer/ldc0.17.2/ldc2-0.17.2-linux-x86_64/bin/ldc2
 compiler.ldc017.name=ldc 0.17.2 (dlang 2.068.2)
+compiler.ldc017.intelAsm=-x86-asm-syntax=intel
+compiler.ldc017.asmFlag=-output-s
+compiler.ldc017.outputFlag=-of
 
 compiler.ldc100.exe=/opt/gcc-explorer/ldc1.0.0/ldc2-1.0.0-linux-x86_64/bin/ldc2
 compiler.ldc100.name=ldc 1.0.0 (dlang 2.070.2)
+compiler.ldc100.intelAsm=-x86-asm-syntax=intel
+compiler.ldc100.asmFlag=-output-s
+compiler.ldc100.outputFlag=-of

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -269,14 +269,14 @@ Compile.prototype.compile = function (source, compiler, options, filters) {
         }
         var compileToAsm;
         if (!filters.binary) {
-            compileToAsm = compilerProps("compileToAsm", "-S").split(" ");
+            compileToAsm = compilerProps("compileToAsm", compilerInfo.asmFlag).split(" ");
         } else {
             compileToAsm = compilerProps("compileToBinary", "").split(" ");
         }
         if (compilerInfo.isCl) {
             options = options.concat(['/c', '/Fa' + outputFilename, '/Fo' + outputFilename + ".obj"]);
         } else {
-            options = options.concat(['-g', '-o', outputFilename]);
+            options = options.concat(['-g', compilerInfo.outputFlag, outputFilename]);
         }
         options = options.concat(compileToAsm).concat([inputFilename]);
 


### PR DESCRIPTION
This change makes the assembly-output and output-filename flags configurable, and sets them correctly for LDC.

Also includes:
- make the Makefile work with DMD environment variable pointing to a DMD-compatible D compiler
- fix demangling of D symbols on OS X

With these changes, LDC works correctly locally (except that the output is not colorized)