### PR TITLE
Fix file match for colorizing

### DIFF
--- a/lib/asm.js
+++ b/lib/asm.js
@@ -116,7 +116,7 @@
         var directive = /^\s*\..*$/;
         var commentOnly = /^\s*(#|@|\/\/).*/;
         var sourceTag = /^\s*\.loc\s+(\d+)\s+(\d+).*/;
-        var stdInLooking = /.*<stdin>|-/;
+        var stdInLooking = /.*<stdin>|-|example/;
         var endBlock = /\.(cfi_endproc|data|text|section)/;
         var source = null;
         asmLines.forEach(function (line) {


### PR DESCRIPTION
I did a quick check and I think all languages use "example" in the source filename.