### PR TITLE
Change output assembly file extension to lowercase 's'

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -260,7 +260,7 @@ Compile.prototype.compile = function (source, compiler, options, filters) {
         postProcess = postProcess.filter(function (x) {
             return x;
         });
-        var outputFilename = path.join(dirPath, 'output.S');
+        var outputFilename = path.join(dirPath, 'output.s');
         if (compilerInfo.options) {
             options = options.concat(compilerInfo.options.split(" "));
         }


### PR DESCRIPTION
This works around a bug in the LDC compiler where the output extension is converted to lowercase.