### PR TITLE
Fix undefined compiler flag issue

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -268,15 +268,17 @@ Compile.prototype.compile = function (source, compiler, options, filters) {
             options = options.concat(compilerInfo.intelAsm.split(" "));
         }
         var compileToAsm;
+        var asmFlag = compilerInfo.asmFlag ? compilerInfo.asmFlag : "-S";
+        var outputFlag = compilerInfo.outputFlag ? compilerInfo.outputFlag : "-o";
         if (!filters.binary) {
-            compileToAsm = compilerProps("compileToAsm", compilerInfo.asmFlag).split(" ");
+            compileToAsm = compilerProps("compileToAsm", asmFlag).split(" ");
         } else {
             compileToAsm = compilerProps("compileToBinary", "").split(" ");
         }
         if (compilerInfo.isCl) {
             options = options.concat(['/c', '/Fa' + outputFilename, '/Fo' + outputFilename + ".obj"]);
         } else {
-            options = options.concat(['-g', compilerInfo.outputFlag, outputFilename]);
+            options = options.concat(['-g', outputFlag, outputFilename]);
         }
         options = options.concat(compileToAsm).concat([inputFilename]);
 


### PR DESCRIPTION
I don't fully understand, but this fix is needed to make the C compilers work locally on my machine again. `compilerInfo.asmFlag` and `compilerInfo.outputFlag` may be undefined (although I thought I had set a default value for them)
