### PR TITLE
LDC: remove the dlang version number

### DIFF
--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -12,19 +12,19 @@ compiler.gdc52.exe=/opt/gcc-explorer/gdc5.2.0/x86_64-pc-linux-gnu/bin/gdc
 compiler.gdc52.name=gdc 5.2.0
 
 compiler.ldc017.exe=/opt/gcc-explorer/ldc0.17.2/ldc2-0.17.2-linux-x86_64/bin/ldc2
-compiler.ldc017.name=ldc 0.17.2 (dlang 2.068.2)
+compiler.ldc017.name=ldc 0.17.2
 compiler.ldc017.intelAsm=-x86-asm-syntax=intel
 compiler.ldc017.asmFlag=-output-s
 compiler.ldc017.outputFlag=-of
 
 compiler.ldc100.exe=/opt/gcc-explorer/ldc1.0.0/ldc2-1.0.0-linux-x86_64/bin/ldc2
-compiler.ldc100.name=ldc 1.0.0 (dlang 2.070.2)
+compiler.ldc100.name=ldc 1.0.0
 compiler.ldc100.intelAsm=-x86-asm-syntax=intel
 compiler.ldc100.asmFlag=-output-s
 compiler.ldc100.outputFlag=-of
 
 compiler.ldc110.exe=/opt/gcc-explorer/ldc1.1.0-beta3/ldc2-1.1.0-beta3-linux-x86_64/bin/ldc2
-compiler.ldc110.name=ldc 1.1.0-beta3 (dlang 2.071.2)
+compiler.ldc110.name=ldc 1.1.0-b3
 compiler.ldc110.intelAsm=-x86-asm-syntax=intel
 compiler.ldc110.asmFlag=-output-s
 compiler.ldc110.outputFlag=-of


### PR DESCRIPTION
This reduces the length of the compiler name to a manageable size.