### PR TITLE
[debug info] Pass -g at the start of the command line.

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -295,7 +295,7 @@ Compile.prototype.compile = function (source, compiler, options, filters) {
         if (compilerInfo.isCl) {
             options = options.concat(['/FAsc', '/c', '/Fa' + filename(outputFilename), '/Fo' + filename(outputFilename) + ".obj"]);
         } else {
-            options = options.concat(['-g', outputFlag, filename(outputFilename)]);
+            options = ['-g', outputFlag, filename(outputFilename)].concat(options);
         }
         options = options.concat(compileToAsm).concat([filename(inputFilename)]);
 


### PR DESCRIPTION
By passing -g at the beginning of the CLI args, debug info noise
can be turned off by passing -g0 in the args.
It's also possible to pass -gline-tables-only if line colouring is
desired and we want to avoid most debug info noise.

Check the difference between `-g0 -emit-llvm` and `-emit-llvm` on clang.
Also check the difference between the default (`-g`) `-g0` and
`-gline-tables-only` on any gcc/clang asm (with line colouring on).