### PR TITLE
Enable binary output for D compilers

### DIFF
--- a/etc/config/d.defaults.properties
+++ b/etc/config/d.defaults.properties
@@ -1,4 +1,7 @@
 compilers=/usr/bin/gdc:/usr/bin/gdc-4.4:/usr/bin/gdc-4.6
 compileFilename=example.d
 postProcess=d/demangle
-supportsBinary=false
+supportsBinary=true
+stubRe=\bmain\b
+stubText=int main(){return 0;/*stub provided by Compiler Explorer*/}
+binaryHideFuncRe=^(_(?!Dmain).*)$


### PR DESCRIPTION
Tested this locally only somewhat. Getting this to work on OS X is a bit of a pain.