### PR TITLE
LDC beta: don't explicitly mention version number

### DIFF
--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -19,5 +19,5 @@ compiler.ldc017.exe=/opt/gcc-explorer/ldc0.17.2/ldc2-0.17.2-linux-x86_64/bin/ldc
 compiler.ldc017.name=ldc 0.17.2
 compiler.ldc100.exe=/opt/gcc-explorer/ldc1.0.0/ldc2-1.0.0-linux-x86_64/bin/ldc2
 compiler.ldc100.name=ldc 1.0.0
-compiler.ldc110.exe=/opt/gcc-explorer/ldc1.1.0-beta3/ldc2-1.1.0-beta3-linux-x86_64/bin/ldc2
-compiler.ldc110.name=ldc 1.1.0-b3
+compiler.ldcbeta.exe=/opt/gcc-explorer/ldcbeta/bin/ldc2
+compiler.ldcbeta.name=ldc beta


### PR DESCRIPTION
Fits together with gcc-explorer-image PR #9, https://github.com/mattgodbolt/gcc-explorer-image/pull/9.